### PR TITLE
Upgrade JGit to 4.5 to prevent NoSuchMethodError

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <artifactId>salesforce-migration-assistant-plugin</artifactId>
     <name>Salesforce Migration Assistant</name>
-    <version>2.2.3-SNAPSHOT</version>
+    <version>2.2.3</version>
     <packaging>hpi</packaging>
 
     <developers>
@@ -82,23 +82,13 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>3.5.1.201410131835-r</version>
+            <version>4.5.0.201609210915-r</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.ws</groupId>
-            <artifactId>jaxws-rt</artifactId>
-            <version>2.2</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.ws</groupId>
-            <artifactId>policy</artifactId>
-            <version>2.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>

--- a/src/main/java/org/jenkinsci/plugins/sma/SMABuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/sma/SMABuilder.java
@@ -222,10 +222,10 @@ public class SMABuilder extends Builder
         private String maxPoll = "200";
         private String pollWait = "30000";
         private String runTestRegex = ".*[T|t]est.*";
-        private String proxyServer;
-        private String proxyUser;
-        private String proxyPass;
-        private Integer proxyPort;
+        private String proxyServer = "";
+        private String proxyUser = "";
+        private String proxyPass = "";
+        private Integer proxyPort = 0;
 
 
         public DescriptorImpl()

--- a/src/main/java/org/jenkinsci/plugins/sma/SMAGit.java
+++ b/src/main/java/org/jenkinsci/plugins/sma/SMAGit.java
@@ -203,7 +203,7 @@ public class SMAGit
             throw new IllegalStateException("Did not find expected file '" + repoItem + "'");
         }
 
-        reader.release();
+        reader.close();
 
         return data;
     }
@@ -243,7 +243,7 @@ public class SMAGit
             }
         }
 
-        reader.release();
+        reader.close();
 
         return contents;
     }

--- a/src/main/java/org/jenkinsci/plugins/sma/SMARunner.java
+++ b/src/main/java/org/jenkinsci/plugins/sma/SMARunner.java
@@ -31,6 +31,7 @@ public class SMARunner
      * Wrapper for coordinating the configuration of the running job
      *
      * @param jobVariables
+     * @param prTargetBranch
      * @throws Exception
      */
     public SMARunner(EnvVars jobVariables, String prTargetBranch) throws Exception
@@ -38,8 +39,6 @@ public class SMARunner
         // Get envvars to initialize SMAGit
         Boolean shaOverride = false;
         currentCommit = jobVariables.get("GIT_COMMIT");
-        Boolean ghprbJob = (jobVariables.get("ghprbSourceBranch") != null);
-        String buildCause = jobVariables.get("BUILD_CAUSE");
         String pathToWorkspace = jobVariables.get("WORKSPACE");
         String jobName = jobVariables.get("JOB_NAME");
         String buildNumber = jobVariables.get("BUILD_NUMBER");
@@ -68,7 +67,7 @@ public class SMARunner
         }
 
         // Configure using pull request logic
-        if (ghprbJob || buildCause.equals("GITHUBPULLREQUESTCAUSE") && !shaOverride)
+        if (!prTargetBranch.isEmpty() && !shaOverride)
         {
             deployAll = false;
             git = new SMAGit(pathToWorkspace, currentCommit, prTargetBranch, SMAGit.Mode.PRB);

--- a/src/test/java/org/jenkinsci/plugins/sma/SMAGitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/sma/SMAGitTest.java
@@ -68,11 +68,12 @@ public class SMAGitTest
         RevCommit firstCommit = new Git(repository).commit().setMessage("Add deleteThis and modifyThis").call();
         oldSha = firstCommit.getName();
 
-
         //Delete the deletion file, modify the modification file, and add the addition file
         new Git(repository).rm().addFilepattern("src/classes/deleteThis.cls").call();
         new Git(repository).rm().addFilepattern("src/classes/deleteThis.cls-meta.xml").call();
-        modification.setExecutable(true);
+        PrintWriter out = new PrintWriter(modification.getPath());
+        out.println("Modified the page");
+        out.close();
         addition = createFile("addThis.trigger", triggersPath);
         addMeta = createFile("addThis.trigger-meta.xml", triggersPath);
         new Git(repository).add().addFilepattern("src/pages/modifyThis.page").call();


### PR DESCRIPTION
SMAGit was using ObjectReader.release(). This has been removed in favor of ObjectReader.close().
Also, simplify the pull request builder logic to only detect the prTargetBranch to determine if a build should use pr logic.

Resolves #11